### PR TITLE
Fixed error importing rpm key

### DIFF
--- a/manifests/rpm_gpg_key.pp
+++ b/manifests/rpm_gpg_key.pp
@@ -24,7 +24,7 @@ class remi::rpm_gpg_key (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => file('remi/RPM-GPG-KEY-remi'),
+    source => 'puppet:///modules/remi/RPM-GPG-KEY-remi',
     before  => Exec['import-remi'],
   }
 


### PR DESCRIPTION
Found the issue importing the RPM key, change the resource type from file to content