### PR TITLE
Wrap epel declaration in if statement

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@
 class remi (
   $ensure                                = present,
   $path                                  = '/etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
+  $use_epel                              = true,
 
   $remi_baseurl                          = absent,
   $remi_mirrorlist                       = "http://rpms.remirepo.net/enterprise/${::operatingsystemmajrelease}/remi/mirror",
@@ -117,7 +118,9 @@ class remi (
   $remi_php70_test_debuginfo_exclude     = undef,
 ){
 
-  require epel
+  if $use_epel {
+    require epel
+  }
 
   if ($::osfamily == 'RedHat' and $::operatingsystem !~ /Fedora|Amazon/) {
     yumrepo {


### PR DESCRIPTION
We are currently already declaring the use of the epel class on a wider scope, so having the class declared specifically by a module clashes, resulting in a duplicate declaration.

This pull request makes the "require epel" part optional. use_epel defaults to true, but may be set to false to ignore declaration of the class.