### PR TITLE
Add support for configuring a proxy on remi repos

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@ class remi (
   $ensure                                = present,
   $path                                  = '/etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
   $use_epel                              = true,
+  $proxy                                 = absent,
+  $proxy_password                        = absent,
+  $proxy_username                        = absent,
 
   $remi_baseurl                          = absent,
   $remi_mirrorlist                       = "http://cdn.remirepo.net/enterprise/${::operatingsystemmajrelease}/remi/mirror",
@@ -177,183 +180,249 @@ class remi (
 
     yumrepo {
       'remi':
-        descr       => "Remi's RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-        baseurl     => $remi_baseurl,
-        mirrorlist  => $remi_mirrorlist,
-        enabled     => $remi_enabled,
-        includepkgs => $remi_includepkgs,
-        exclude     => $remi_exclude;
+        descr          => "Remi's RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => $remi_baseurl,
+        mirrorlist     => $remi_mirrorlist,
+        enabled        => $remi_enabled,
+        includepkgs    => $remi_includepkgs,
+        exclude        => $remi_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-php54':
-        descr       => "Remi's PHP 5.4 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-        baseurl     => $remi_php54_baseurl,
-        mirrorlist  => $remi_php54_mirrorlist,
-        enabled     => $remi_php54_enabled,
-        includepkgs => $remi_php54_includepkgs,
-        exclude     => $remi_php54_exclude;
+        descr          => "Remi's PHP 5.4 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => $remi_php54_baseurl,
+        mirrorlist     => $remi_php54_mirrorlist,
+        enabled        => $remi_php54_enabled,
+        includepkgs    => $remi_php54_includepkgs,
+        exclude        => $remi_php54_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-php55':
-        descr       => "Remi's PHP 5.5 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-        baseurl     => $remi_php55_baseurl,
-        mirrorlist  => $remi_php55_mirrorlist,
-        enabled     => $remi_php55_enabled,
-        includepkgs => $remi_php55_includepkgs,
-        exclude     => $remi_php55_exclude;
+        descr          => "Remi's PHP 5.5 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => $remi_php55_baseurl,
+        mirrorlist     => $remi_php55_mirrorlist,
+        enabled        => $remi_php55_enabled,
+        includepkgs    => $remi_php55_includepkgs,
+        exclude        => $remi_php55_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-php56':
-        descr       => "Remi's PHP 5.6 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-        baseurl     => $remi_php56_baseurl,
-        mirrorlist  => $remi_php56_mirrorlist,
-        enabled     => $remi_php56_enabled,
-        includepkgs => $remi_php56_includepkgs,
-        exclude     => $remi_php56_exclude;
+        descr          => "Remi's PHP 5.6 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => $remi_php56_baseurl,
+        mirrorlist     => $remi_php56_mirrorlist,
+        enabled        => $remi_php56_enabled,
+        includepkgs    => $remi_php56_includepkgs,
+        exclude        => $remi_php56_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-test':
-        descr       => "Remi's test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-        baseurl     => $remi_test_baseurl,
-        mirrorlist  => $remi_test_mirrorlist,
-        enabled     => $remi_test_enabled,
-        includepkgs => $remi_test_includepkgs,
-        exclude     => $remi_test_exclude;
+        descr          => "Remi's test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+        baseurl        => $remi_test_baseurl,
+        mirrorlist     => $remi_test_mirrorlist,
+        enabled        => $remi_test_enabled,
+        includepkgs    => $remi_test_includepkgs,
+        exclude        => $remi_test_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-debuginfo':
-        descr       => "Remi's RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-        baseurl     => $remi_debuginfo_baseurl,
-        mirrorlist  => $remi_debuginfo_mirrorlist,
-        enabled     => $remi_debuginfo_enabled,
-        includepkgs => $remi_debuginfo_includepkgs,
-        exclude     => $remi_debuginfo_exclude;
+        descr          => "Remi's RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+        baseurl        => $remi_debuginfo_baseurl,
+        mirrorlist     => $remi_debuginfo_mirrorlist,
+        enabled        => $remi_debuginfo_enabled,
+        includepkgs    => $remi_debuginfo_includepkgs,
+        exclude        => $remi_debuginfo_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-php55-debuginfo':
-        descr       => "Remi's PHP 5.5 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-        baseurl     => $remi_php55_debuginfo_baseurl,
-        mirrorlist  => $remi_php55_debuginfo_mirrorlist,
-        enabled     => $remi_php55_debuginfo_enabled,
-        includepkgs => $remi_php55_debuginfo_includepkgs,
-        exclude     => $remi_php55_debuginfo_exclude;
+        descr          => "Remi's PHP 5.5 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+        baseurl        => $remi_php55_debuginfo_baseurl,
+        mirrorlist     => $remi_php55_debuginfo_mirrorlist,
+        enabled        => $remi_php55_debuginfo_enabled,
+        includepkgs    => $remi_php55_debuginfo_includepkgs,
+        exclude        => $remi_php55_debuginfo_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-php56-debuginfo':
-        descr       => "Remi's PHP 5.6 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-        baseurl     => $remi_php56_debuginfo_baseurl,
-        mirrorlist  => $remi_php56_debuginfo_mirrorlist,
-        enabled     => $remi_php56_debuginfo_enabled,
-        includepkgs => $remi_php56_debuginfo_includepkgs,
-        exclude     => $remi_php56_debuginfo_exclude;
+        descr          => "Remi's PHP 5.6 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+        baseurl        => $remi_php56_debuginfo_baseurl,
+        mirrorlist     => $remi_php56_debuginfo_mirrorlist,
+        enabled        => $remi_php56_debuginfo_enabled,
+        includepkgs    => $remi_php56_debuginfo_includepkgs,
+        exclude        => $remi_php56_debuginfo_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
 
       'remi-test-debuginfo':
-        descr       => "Remi's test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-        baseurl     => $remi_test_debuginfo_baseurl,
-        mirrorlist  => $remi_test_debuginfo_mirrorlist,
-        enabled     => $remi_test_debuginfo_enabled,
-        includepkgs => $remi_test_debuginfo_includepkgs,
-        exclude     => $remi_test_debuginfo_exclude;
+        descr          => "Remi's test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+        baseurl        => $remi_test_debuginfo_baseurl,
+        mirrorlist     => $remi_test_debuginfo_mirrorlist,
+        enabled        => $remi_test_debuginfo_enabled,
+        includepkgs    => $remi_test_debuginfo_includepkgs,
+        exclude        => $remi_test_debuginfo_exclude,
+        proxy          => $proxy,
+        proxy_password => $proxy_password,
+        proxy_username => $proxy_username;
     }
 
     if ($::operatingsystemmajrelease != '5') {
       yumrepo {
         'remi-safe':
-          descr       => "Safe Remi's test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_safe_baseurl,
-          mirrorlist  => $remi_safe_mirrorlist,
-          enabled     => $remi_safe_enabled,
-          includepkgs => $remi_safe_includepkgs,
-          exclude     => $remi_safe_exclude;
+          descr          => "Safe Remi's test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_safe_baseurl,
+          mirrorlist     => $remi_safe_mirrorlist,
+          enabled        => $remi_safe_enabled,
+          includepkgs    => $remi_safe_includepkgs,
+          exclude        => $remi_safe_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php70':
-          descr       => "Remi's PHP 7.0 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_php70_baseurl,
-          mirrorlist  => $remi_php70_mirrorlist,
-          enabled     => $remi_php70_enabled,
-          includepkgs => $remi_php70_includepkgs,
-          exclude     => $remi_php70_exclude;
+          descr          => "Remi's PHP 7.0 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_php70_baseurl,
+          mirrorlist     => $remi_php70_mirrorlist,
+          enabled        => $remi_php70_enabled,
+          includepkgs    => $remi_php70_includepkgs,
+          exclude        => $remi_php70_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php70-debuginfo':
-          descr       => "Remi's PHP 7.0 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-          baseurl     => $remi_php70_debuginfo_baseurl,
-          mirrorlist  => $remi_php70_debuginfo_mirrorlist,
-          enabled     => $remi_php70_debuginfo_enabled,
-          includepkgs => $remi_php70_debuginfo_includepkgs,
-          exclude     => $remi_php70_debuginfo_exclude;
+          descr          => "Remi's PHP 7.0 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+          baseurl        => $remi_php70_debuginfo_baseurl,
+          mirrorlist     => $remi_php70_debuginfo_mirrorlist,
+          enabled        => $remi_php70_debuginfo_enabled,
+          includepkgs    => $remi_php70_debuginfo_includepkgs,
+          exclude        => $remi_php70_debuginfo_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php70-test':
-          descr       => "Remi's PHP 7.0 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_php70_test_baseurl,
-          mirrorlist  => $remi_php70_test_mirrorlist,
-          enabled     => $remi_php70_test_enabled,
-          includepkgs => $remi_php70_test_includepkgs,
-          exclude     => $remi_php70_test_exclude;
+          descr          => "Remi's PHP 7.0 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_php70_test_baseurl,
+          mirrorlist     => $remi_php70_test_mirrorlist,
+          enabled        => $remi_php70_test_enabled,
+          includepkgs    => $remi_php70_test_includepkgs,
+          exclude        => $remi_php70_test_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php70-test-debuginfo':
-          descr       => "Remi's PHP 7.0 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-          baseurl     => $remi_php70_test_debuginfo_baseurl,
-          mirrorlist  => $remi_php70_test_debuginfo_mirrorlist,
-          enabled     => $remi_php70_test_debuginfo_enabled,
-          includepkgs => $remi_php70_test_debuginfo_includepkgs,
-          exclude     => $remi_php70_test_debuginfo_exclude;
+          descr          => "Remi's PHP 7.0 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+          baseurl        => $remi_php70_test_debuginfo_baseurl,
+          mirrorlist     => $remi_php70_test_debuginfo_mirrorlist,
+          enabled        => $remi_php70_test_debuginfo_enabled,
+          includepkgs    => $remi_php70_test_debuginfo_includepkgs,
+          exclude        => $remi_php70_test_debuginfo_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php71':
-          descr       => "Remi's PHP 7.1 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_php71_baseurl,
-          mirrorlist  => $remi_php71_mirrorlist,
-          enabled     => $remi_php71_enabled,
-          includepkgs => $remi_php71_includepkgs,
-          exclude     => $remi_php71_exclude;
+          descr          => "Remi's PHP 7.1 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_php71_baseurl,
+          mirrorlist     => $remi_php71_mirrorlist,
+          enabled        => $remi_php71_enabled,
+          includepkgs    => $remi_php71_includepkgs,
+          exclude        => $remi_php71_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php71-debuginfo':
-          descr       => "Remi's PHP 7.1 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-          baseurl     => $remi_php71_debuginfo_baseurl,
-          mirrorlist  => $remi_php71_debuginfo_mirrorlist,
-          enabled     => $remi_php71_debuginfo_enabled,
-          includepkgs => $remi_php71_debuginfo_includepkgs,
-          exclude     => $remi_php71_debuginfo_exclude;
+          descr          => "Remi's PHP 7.1 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+          baseurl        => $remi_php71_debuginfo_baseurl,
+          mirrorlist     => $remi_php71_debuginfo_mirrorlist,
+          enabled        => $remi_php71_debuginfo_enabled,
+          includepkgs    => $remi_php71_debuginfo_includepkgs,
+          exclude        => $remi_php71_debuginfo_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php71-test':
-          descr       => "Remi's PHP 7.1 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_php71_test_baseurl,
-          mirrorlist  => $remi_php71_test_mirrorlist,
-          enabled     => $remi_php71_test_enabled,
-          includepkgs => $remi_php71_test_includepkgs,
-          exclude     => $remi_php71_test_exclude;
+          descr          => "Remi's PHP 7.1 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_php71_test_baseurl,
+          mirrorlist     => $remi_php71_test_mirrorlist,
+          enabled        => $remi_php71_test_enabled,
+          includepkgs    => $remi_php71_test_includepkgs,
+          exclude        => $remi_php71_test_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php71-test-debuginfo':
-          descr       => "Remi's PHP 7.1 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-          baseurl     => $remi_php71_test_debuginfo_baseurl,
-          mirrorlist  => $remi_php71_test_debuginfo_mirrorlist,
-          enabled     => $remi_php71_test_debuginfo_enabled,
-          includepkgs => $remi_php71_test_debuginfo_includepkgs,
-          exclude     => $remi_php71_test_debuginfo_exclude;
+          descr          => "Remi's PHP 7.1 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+          baseurl        => $remi_php71_test_debuginfo_baseurl,
+          mirrorlist     => $remi_php71_test_debuginfo_mirrorlist,
+          enabled        => $remi_php71_test_debuginfo_enabled,
+          includepkgs    => $remi_php71_test_debuginfo_includepkgs,
+          exclude        => $remi_php71_test_debuginfo_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php72':
-          descr       => "Remi's PHP 7.2 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_php72_baseurl,
-          mirrorlist  => $remi_php72_mirrorlist,
-          enabled     => $remi_php72_enabled,
-          includepkgs => $remi_php72_includepkgs,
-          exclude     => $remi_php72_exclude;
+          descr          => "Remi's PHP 7.2 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_php72_baseurl,
+          mirrorlist     => $remi_php72_mirrorlist,
+          enabled        => $remi_php72_enabled,
+          includepkgs    => $remi_php72_includepkgs,
+          exclude        => $remi_php72_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php72-debuginfo':
-          descr       => "Remi's PHP 7.2 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-          baseurl     => $remi_php72_debuginfo_baseurl,
-          mirrorlist  => $remi_php72_debuginfo_mirrorlist,
-          enabled     => $remi_php72_debuginfo_enabled,
-          includepkgs => $remi_php72_debuginfo_includepkgs,
-          exclude     => $remi_php72_debuginfo_exclude;
+          descr          => "Remi's PHP 7.2 RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+          baseurl        => $remi_php72_debuginfo_baseurl,
+          mirrorlist     => $remi_php72_debuginfo_mirrorlist,
+          enabled        => $remi_php72_debuginfo_enabled,
+          includepkgs    => $remi_php72_debuginfo_includepkgs,
+          exclude        => $remi_php72_debuginfo_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php72-test':
-          descr       => "Remi's PHP 7.2 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
-          baseurl     => $remi_php72_test_baseurl,
-          mirrorlist  => $remi_php72_test_mirrorlist,
-          enabled     => $remi_php72_test_enabled,
-          includepkgs => $remi_php72_test_includepkgs,
-          exclude     => $remi_php72_test_exclude;
+          descr          => "Remi's PHP 7.2 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+          baseurl        => $remi_php72_test_baseurl,
+          mirrorlist     => $remi_php72_test_mirrorlist,
+          enabled        => $remi_php72_test_enabled,
+          includepkgs    => $remi_php72_test_includepkgs,
+          exclude        => $remi_php72_test_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
 
         'remi-php72-test-debuginfo':
-          descr       => "Remi's PHP 7.2 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
-          baseurl     => $remi_php72_test_debuginfo_baseurl,
-          mirrorlist  => $remi_php72_test_debuginfo_mirrorlist,
-          enabled     => $remi_php72_test_debuginfo_enabled,
-          includepkgs => $remi_php72_test_debuginfo_includepkgs,
-          exclude     => $remi_php72_test_debuginfo_exclude;
+          descr          => "Remi's PHP 7.2 test RPM repository for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - debuginfo",
+          baseurl        => $remi_php72_test_debuginfo_baseurl,
+          mirrorlist     => $remi_php72_test_debuginfo_mirrorlist,
+          enabled        => $remi_php72_test_debuginfo_enabled,
+          includepkgs    => $remi_php72_test_debuginfo_includepkgs,
+          exclude        => $remi_php72_test_debuginfo_exclude,
+          proxy          => $proxy,
+          proxy_password => $proxy_password,
+          proxy_username => $proxy_username;
       }
     }
   } else {


### PR DESCRIPTION
This adds support for configuring a proxy when the yum repo files are defined. A new use case example could be:

```puppet
class { 'remi':
  remi_safe_enabled  => 1,
  remi_php71_enabled => 1,
  proxy              => 'proxy.example.com',
  proxy_password     => 'password',
  proxy_username     => 'username',
}
```
I didn't want to assume you'd want this in the README so didn't force include it. I also didn't bump the version number of the plugin - figured you'd do that with your own scheme.

Let me know if you have any questions or need some additional information.