### PR TITLE
Update for gpg key handler for RHEL 8

### DIFF
--- a/manifests/rpm_gpg_key.pp
+++ b/manifests/rpm_gpg_key.pp
@@ -31,7 +31,7 @@ class remi::rpm_gpg_key (
   exec { 'import-remi':
     command => "rpm --import ${path}",
     path    => ['/bin', '/usr/bin'],
-    unless  => "rpm -q gpg-pubkey-$(gpg --throw-keyids ${path} | grep pub | cut -c 12-19 | tr '[A-Z]' '[a-z]')",
+    unless  => "rpm -q gpg-pubkey-$(echo $(gpg -q --throw-keyids --keyid-format short < ${path}) | grep pub | cut -f2 -d/ | cut -f1 -d' ' | tr '[A-Z]' '[a-z]')",
   }
 
 }


### PR DESCRIPTION
Howdy!  RHEL8 changes the output of gpg a bit and it makes rpm_gpg_key fail to properly detect that the associated key is installed.  This is basically the same fix as:
https://github.com/stahnma/puppet-module-epel/pull/84
from the epel module.

That said, it looks like the RHEL8 rpms have been signed with one of the newer keys.  I'm also working on a separate PR to provide a solution for that.  That said, the fix for that is going to be a little more drastic.