### PR TITLE
Loosening version requirements on stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 6.0.0"
+      "version_requirement": ">= 3.0.0"
     },
     {
       "name": "stahnma/epel",


### PR DESCRIPTION
puppetlabs-stdlib went to version 6.0 on 2019-05-10 -- I'm not sure if there are any incompatibilities between this module and stdlib >= 6.0, but it seems to work so far.
